### PR TITLE
Declare package.json as an ES module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6191,22 +6191,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "amazon-clone",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "packageManager": "npm@11.19.0",
   "dependencies": {
     "@emotion/react": "^11.14.0",


### PR DESCRIPTION
## Summary
- Follow-up to #197, which merged before this fix was pushed to that branch.
- `vite.config.js` already uses ESM `import`/`export default` syntax; without `"type": "module"` in `package.json`, Vite's native config loader warns about loading it as CommonJS.
- No CommonJS (`require`/`module.exports`) usage anywhere else in the project, so this is a clean, isolated fix.
- Also drops a stale `extraneous: true` `yaml` entry from `package-lock.json` that a fresh `npm install` cleaned up.

## Test plan
- [x] `npm run build` succeeds with no CJS/ESM warning
- [x] Fresh `rm -rf node_modules && npm install` succeeds cleanly, 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)